### PR TITLE
Deploy automatico com github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,17 +4,22 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '20.x'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -23,7 +28,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          branch: gh-pages
-          folder: dist
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main", "convert-to-vue3" ]
 
 permissions:
   contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ "main", "convert-to-vue3" ]
+    branches: [ "main" ]
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@
 npm ci # (instala as dependecias declaradas no package.json)
 npm run dev # sobe o ambiente de desenvolvimento
 ```
+
+## Deploy
+
+O deploy do frontend é feito automaticamente usando github actions.
+
+O resultado ta disponivel em https://drautismo.github.io/drautismo/

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [
     vue(),
   ],
-  base: '/drautismo/', // Replace with your repository name
+  base: '/drautismo/', // Substitua pelo nome do seu repositório
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
O deploy automatico pro github pages agora tá funcionando.

O github actions aqui vai construir o frontend e publicar no endereço https://drautismo.github.io/drautismo/

Obs: Isso é só pra gente ter um lugar facil pra compartilhar e mostrar pra outras pessoas. Não é o lugar onde a aplicação vai viver de verdade (nem teria como pq o github pages só consegue servir conteúdo estático e isso aqui vai precisar de um backend)

https://www.loom.com/share/96e86d5c2ffb4d89b7fdfbdfe394799d